### PR TITLE
Yum task updated for escalated privileges

### DIFF
--- a/linux_patching/roles/patching/tasks/update_NO_reboot.yml
+++ b/linux_patching/roles/patching/tasks/update_NO_reboot.yml
@@ -117,6 +117,9 @@
     name: "*"
     state: latest
     exclude: kernel*, glibc*, linux-firmware*, systemd*, dbus*, udev*
+  become_user: root
+  become_method: sudo
+  become: true
   when: ansible_distribution in supported_distros
   register: yum_result
 

--- a/linux_patching/roles/patching/tasks/update_with_reboot.yml
+++ b/linux_patching/roles/patching/tasks/update_with_reboot.yml
@@ -118,6 +118,9 @@
     name: "*"
     state: latest
     #exclude: httpd*, php* 
+  become_user: root
+  become_method: sudo
+  become: true
   when: ansible_distribution in supported_distros
   register: yum_result
 


### PR DESCRIPTION
Yum update will fail on Ansible as this task requires root privileges.